### PR TITLE
Add `channelId` to labels to avoid crashes on duplicate channel names

### DIFF
--- a/pkg/collector/channel.go
+++ b/pkg/collector/channel.go
@@ -2,14 +2,14 @@ package collector
 
 import (
 	"log"
-
+	"fmt"
 	"github.com/hikhvar/ts3exporter/pkg/serverquery"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const channelSubsystem = "channel"
 
-var channelLabels = []string{virtualServerLabel, channelLabel}
+var channelLabels = []string{virtualServerLabel, channelId, channelLabel}
 
 type Channel struct {
 	executor        serverquery.Executor
@@ -55,15 +55,15 @@ func (c *Channel) Collect(met chan<- prometheus.Metric) {
 		log.Printf("failed to refresh channel view: %v", err)
 	}
 	for _, ch := range channels.All() {
-		met <- prometheus.MustNewConstMetric(c.ClientsOnline, prometheus.GaugeValue, float64(ch.ClientsOnline), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.MaxClients, prometheus.GaugeValue, float64(ch.MaxClients), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Codec, prometheus.GaugeValue, float64(ch.Codec), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.CodecQuality, prometheus.GaugeValue, float64(ch.CodecQuality), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.LatencyFactor, prometheus.GaugeValue, float64(ch.LatencyFactor), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Unencrypted, prometheus.GaugeValue, float64(ch.Unencrypted), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Permanent, prometheus.GaugeValue, float64(ch.Permanent), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.SemiPermanent, prometheus.GaugeValue, float64(ch.SemiPermanent), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Default, prometheus.GaugeValue, float64(ch.Default), ch.HostingServer.Name, ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Password, prometheus.GaugeValue, float64(ch.Password), ch.HostingServer.Name, ch.Name)
+		met <- prometheus.MustNewConstMetric(c.ClientsOnline, prometheus.GaugeValue, float64(ch.ClientsOnline), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.MaxClients, prometheus.GaugeValue, float64(ch.MaxClients), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Codec, prometheus.GaugeValue, float64(ch.Codec), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.CodecQuality, prometheus.GaugeValue, float64(ch.CodecQuality), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.LatencyFactor, prometheus.GaugeValue, float64(ch.LatencyFactor), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Unencrypted, prometheus.GaugeValue, float64(ch.Unencrypted), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Permanent, prometheus.GaugeValue, float64(ch.Permanent), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.SemiPermanent, prometheus.GaugeValue, float64(ch.SemiPermanent), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Default, prometheus.GaugeValue, float64(ch.Default), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Password, prometheus.GaugeValue, float64(ch.Password), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
 	}
 }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -5,6 +5,7 @@ import "fmt"
 const namespace = "ts3"
 const virtualServerLabel = "virtualserver"
 const channelLabel = "channel"
+const channelId = "channelId"
 
 // fqdn generates a full qualified name of a metric. Given the subsystem and the name of the metric.
 func fqdn(subsystem, name string) string {


### PR DESCRIPTION
I've run into the issue where the same virtual server could have duplicate names, as an example:
- Type of game 1
   - Room 1
   - Room 2
- Type of game 2
   - Room 1
   - Room2

So I've added the `channelId` to the labels pushed to the prometheus library, which fixes it (it's not pretty, but you can't always control users right ;) )