### PR TITLE
Fix that exporter metrics were never exposed

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 		seq = append(seq, cInfo)
 	}
 
-	prometheus.MustRegister(append(seq, collector.NewClient(c)))
+	prometheus.MustRegister(append(seq, collector.NewClient(c), internalMetrics))
 	// The Handler function provides a default handler to expose metrics
 	// via an HTTP server. "/metrics" is the usual endpoint for that.
 	http.Handle("/metrics", promhttp.Handler())

--- a/pkg/collector/channel.go
+++ b/pkg/collector/channel.go
@@ -1,10 +1,10 @@
 package collector
 
 import (
-	"log"
 	"fmt"
 	"github.com/hikhvar/ts3exporter/pkg/serverquery"
 	"github.com/prometheus/client_golang/prometheus"
+	"log"
 )
 
 const channelSubsystem = "channel"
@@ -28,6 +28,7 @@ type Channel struct {
 }
 
 func NewChannel(executor serverquery.Executor, internalMetrics *ExporterMetrics) *Channel {
+	internalMetrics.Init(channelSubsystem)
 	return &Channel{
 		executor:        executor,
 		internalMetrics: internalMetrics,
@@ -55,15 +56,15 @@ func (c *Channel) Collect(met chan<- prometheus.Metric) {
 		log.Printf("failed to refresh channel view: %v", err)
 	}
 	for _, ch := range channels.All() {
-		met <- prometheus.MustNewConstMetric(c.ClientsOnline, prometheus.GaugeValue, float64(ch.ClientsOnline), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.MaxClients, prometheus.GaugeValue, float64(ch.MaxClients), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Codec, prometheus.GaugeValue, float64(ch.Codec), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.CodecQuality, prometheus.GaugeValue, float64(ch.CodecQuality), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.LatencyFactor, prometheus.GaugeValue, float64(ch.LatencyFactor), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Unencrypted, prometheus.GaugeValue, float64(ch.Unencrypted), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Permanent, prometheus.GaugeValue, float64(ch.Permanent), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.SemiPermanent, prometheus.GaugeValue, float64(ch.SemiPermanent), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Default, prometheus.GaugeValue, float64(ch.Default), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
-		met <- prometheus.MustNewConstMetric(c.Password, prometheus.GaugeValue, float64(ch.Password), ch.HostingServer.Name, fmt.Sprintf("%d",ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.ClientsOnline, prometheus.GaugeValue, float64(ch.ClientsOnline), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.MaxClients, prometheus.GaugeValue, float64(ch.MaxClients), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Codec, prometheus.GaugeValue, float64(ch.Codec), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.CodecQuality, prometheus.GaugeValue, float64(ch.CodecQuality), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.LatencyFactor, prometheus.GaugeValue, float64(ch.LatencyFactor), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Unencrypted, prometheus.GaugeValue, float64(ch.Unencrypted), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Permanent, prometheus.GaugeValue, float64(ch.Permanent), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.SemiPermanent, prometheus.GaugeValue, float64(ch.SemiPermanent), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Default, prometheus.GaugeValue, float64(ch.Default), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
+		met <- prometheus.MustNewConstMetric(c.Password, prometheus.GaugeValue, float64(ch.Password), ch.HostingServer.Name, fmt.Sprintf("%d", ch.ID), ch.Name)
 	}
 }

--- a/pkg/collector/exporterMetrics.go
+++ b/pkg/collector/exporterMetrics.go
@@ -18,6 +18,11 @@ func NewExporterMetrics() *ExporterMetrics {
 	}
 }
 
+// Init initializes the metrics given a collector label to make sure that they appear even though they might be never updated
+func (i *ExporterMetrics) Init(collector string) {
+	i.refreshErrors.WithLabelValues(collector)
+}
+
 // RefreshError increases the refresh error counter of the given collector by one.
 func (i *ExporterMetrics) RefreshError(collector string) {
 	i.refreshErrors.WithLabelValues(collector).Inc()
@@ -28,5 +33,6 @@ func (i *ExporterMetrics) Describe(descs chan<- *prometheus.Desc) {
 }
 
 func (i *ExporterMetrics) Collect(metrics chan<- prometheus.Metric) {
+	// Ensure that the metric is always initialized
 	i.refreshErrors.Collect(metrics)
 }

--- a/pkg/collector/serverinfo.go
+++ b/pkg/collector/serverinfo.go
@@ -1,10 +1,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/hikhvar/ts3exporter/pkg/serverquery"
 	"github.com/prometheus/client_golang/prometheus"
+	"log"
 )
 
 const serverInfoSubsystem = "serverinfo"
@@ -43,6 +42,7 @@ type ServerInfo struct {
 }
 
 func NewServerInfo(executor serverquery.Executor, internalMetrics *ExporterMetrics) *ServerInfo {
+	internalMetrics.Init(serverInfoSubsystem)
 	return &ServerInfo{
 		executor:                       executor,
 		internalMetrics:                internalMetrics,


### PR DESCRIPTION
In a5cb939f6219ea0dd13c8780dcd551b3e9401a07, a bug was introduced that the exporter metrics never got exposed for collection. Also, there was no initialization for each label set happening, which hid the metrics until at least 1 error occurred. This PR fixes both of these problems.